### PR TITLE
feat: add k3s worker node support and improve playbook structure

### DIFF
--- a/group_vars/workers.yml
+++ b/group_vars/workers.yml
@@ -1,2 +1,3 @@
 controller_node: false
-k3s_agent_args: [] 
+k3s_agent_args:
+  - "--node-label=mylabel=worker"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,13 +1,20 @@
 ---
-- name: Deploy k3s HA cluster
-  hosts: all
+- name: Deploy k3s controllers
+  hosts: controllers
+  become: true
+  vars_files:
+    - ../group_vars/all.yml
+    - ../group_vars/controllers.yml
+  roles:
+    - role: common
+    - role: k3s_controller
+
+- name: Deploy k3s workers
+  hosts: workers
+  vars_files:
+    - ../group_vars/all.yml
+    - ../group_vars/workers.yml
   become: true
   roles:
     - role: common
-      tags: common
-    - role: k3s_controller
-      when: controller_node | default(false)
-      tags: controllers
-    - role: k3s_worker
-      when: not controller_node | default(false)
-      tags: workers 
+    - role: k3s_worker 

--- a/roles/k3s_worker/handlers/main.yml
+++ b/roles/k3s_worker/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# handlers file for k3s_worker
+
+- name: restart k3s-agent
+  ansible.builtin.systemd:
+    name: k3s-agent
+    state: restarted 

--- a/roles/k3s_worker/tasks/main.yml
+++ b/roles/k3s_worker/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+# tasks file for k3s_worker
+- name: Set k3s binary name based on architecture
+  set_fact:
+    k3s_binary_name: >-
+      {% if ansible_architecture == 'aarch64' %}k3s-arm64
+      {% elif ansible_architecture == 'armv7l' %}k3s-armhf
+      {% else %}k3s
+      {% endif %}
+
+- name: Ensure k3s agent binary is present
+  ansible.builtin.get_url:
+    url: "https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/{{ k3s_binary_name }}"
+    dest: /usr/local/bin/k3s
+    mode: '0755'
+    force: yes
+
+- name: Create k3s config directory
+  ansible.builtin.file:
+    path: /etc/rancher/k3s
+    state: directory
+    mode: '0755'
+    recurse: yes
+
+- name: Deploy k3s agent systemd service file
+  ansible.builtin.template:
+    src: k3s-agent.service.j2
+    dest: /etc/systemd/system/k3s-agent.service
+    mode: '0644'
+  notify: restart k3s-agent
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: Enable and start k3s agent service
+  ansible.builtin.service:
+    name: k3s-agent
+    state: started
+    enabled: yes 

--- a/roles/k3s_worker/templates/k3s-agent.service.j2
+++ b/roles/k3s_worker/templates/k3s-agent.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=Lightweight Kubernetes Agent
+Documentation=https://k3s.io
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+ExecStart=/usr/local/bin/k3s agent \
+  --token={{ k3s_token }} \
+  --server https://{{ hostvars[groups['controllers'][0]].ansible_host | default(groups['controllers'][0]) }}:6443 \
+  {% for arg in k3s_agent_args %}{{ arg }} \
+  {% endfor %}
+RestartSec=5s
+LimitNOFILE=1048576
+LimitNPROC=1048576
+TasksMax=infinity
+Delegate=yes
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target 


### PR DESCRIPTION
- Scaffold and implement the k3s_worker role for agent node provisioning
- Update playbooks/site.yml to use separate plays for controllers and workers
- Add group_vars and inventory entries for worker nodes
- Ensure all tasks and handlers are implemented (no skeletons remain, hopefully)